### PR TITLE
Needs local testing/fixing (VR event post)

### DIFF
--- a/collections/_events/2022-11-15—vr-animation-workshop.md
+++ b/collections/_events/2022-11-15—vr-animation-workshop.md
@@ -2,8 +2,8 @@
 author: laura-miller
 start_date: 2022-11-15
 end_date: 2022-11-15
-start_time: 14:00:00
-end_time: 16:00:00
+start_time: '14:00:00'
+end_time: '16:00:00'
 layout: events
 location: 'Clemons Library, 3rd Floor, RMC HTC Vive Immersive Stations 1 and 2'
 slug: 2022-11-15-vr-animation-workshop


### PR DESCRIPTION
Would someone who has current local Jekyll access mind testing/fixing this post? Laura and I couldn't get it working, for some reason, although we compared to/copied from other events. The farthest I got was the event showing up on the SLab.org/events page list, its link to the event details page not working, adding an ending slash to that "nothing found" URL to see the event (which is somehow breaking—something with the markdown to HTML conversion I think, as the first bracket on the second body-text link is showing when it shouldn't be)?

Thanks!