### PR TITLE
Correct staff affiliation

### DIFF
--- a/collections/_people/brandon-walsh.md
+++ b/collections/_people/brandon-walsh.md
@@ -1,5 +1,4 @@
 ---
-department: English
 email: bmw9t@virginia.edu
 first_name: Brandon
 last_name: Walsh

--- a/collections/_people/shane-lin.md
+++ b/collections/_people/shane-lin.md
@@ -1,5 +1,4 @@
 ---
-department: History
 email: ssl2ab@virginia.edu
 first_name: Shane
 last_name: Lin


### PR DESCRIPTION
Correct two departmental staff affiliations. Shane and I were listed in the history and English departments, I bet because it was a holdover from when we were students. I think the old site design didn't list those on people pages? Or if it did I didn't notice it. 

Note that I did this in the web interface so have not tested locally. 