### PR TITLE
Fix: Preserve HTML and Markdown links in updates feed layout (#1212)

### DIFF
--- a/pages/scholarship/updates.html
+++ b/pages/scholarship/updates.html
@@ -30,7 +30,7 @@ regenerate: true
 		
 		<li>
 			<h3>{{ post.date | date: "%B %-d, %Y" }} update: <a href="{{ post.url }}">{{ post.title }}</a></h3>
-		{{ post.content | strip_html | markdownify }}
+		{{ post.content | markdownify }}
 		</li>
 	{% endif %}
 	{% endfor %}


### PR DESCRIPTION
Hi! This PR fixes the issue where links were being stripped from the /updates page feed. 

### What changed:
- Located the template loop inside `pages/scholarship/updates.html`.
- Removed the `strip_html` Liquid filter from the `post.content` rendering string. 
- This ensures that HTML anchor tags and Markdown links are preserved and render correctly as active links, matching how the homepage activity feed behaves. 

Ready for review! Thanks.